### PR TITLE
initialize RNG with urandom if possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_HAVE_HEADERS(stdio.h getopt.h errno.h string.h strings.h sys/types.h unistd.h
 
 AC_CHECK_FUNCS(atol)
 AC_CHECK_FUNCS(srandomdev)
+AC_CHECK_FUNCS(srandom)
 AC_CHECK_FUNCS(getpid)
 AC_CHECK_FUNCS(qsort)
 

--- a/roll.c
+++ b/roll.c
@@ -135,7 +135,7 @@ int roll(int dice) {
    *  j=1+(int) (10.0*rand()/(RAND_MAX+1.0));
    */
 
-#ifdef HAVE_SRANDOMDEV
+#if defined HAVE_SRANDOMDEV || defined HAVE_SRANDOM
   int res = 1+(int)(((double)dice)*random()/(RAND_MAX+1.0));
 #else
   int res = 1+(int)(((double)dice)*rand()/(RAND_MAX+1.0));
@@ -144,6 +144,23 @@ int roll(int dice) {
   return res;
 
 }
+
+#if defined HAVE_SRANDOM
+/*!
+ * \brief       Try to initialize random from /dev/urandom, otherwise fallback on srandom(time(0))
+ */
+static void urandom_init() {
+  FILE* urandom = fopen("/dev/urandom", "rb");
+  if (urandom) {
+    unsigned int seed = 0;
+    fread(&seed, sizeof(seed), 1, urandom);
+    fclose(urandom);
+    srandom(seed ^ time(NULL));
+  }
+  else
+    srandom(time(NULL));
+}
+#endif
 
 /*!
  * \brief       Main program
@@ -158,6 +175,8 @@ int main(int argc, char **argv) {
 
 #ifdef HAVE_SRANDOMDEV
   srandomdev();
+#elif defined HAVE_SRANDOM
+  urandom_init();
 #else
   srand(time(NULL));
 #endif


### PR DESCRIPTION
When using roll on Linux to roll a batch of attacks, it gives the same result as it initializes with time(NULL), which only changes once a second.

This patch reads a seed from /dev/urandom if it's readable, so we can roll different values in the same second. ;)